### PR TITLE
"showMessage" was actually released in GHC 7.10 as "displayException"

### DIFF
--- a/src/Sig/Types.hs
+++ b/src/Sig/Types.hs
@@ -16,7 +16,7 @@ Portability : POSIX
 
 module Sig.Types where
 
-import Control.Exception ( Exception )
+import Control.Exception ( Exception(..) )
 import Data.Aeson
     ( Value(String), ToJSON(..), FromJSON(..), object, (.=), (.:) )
 import Data.ByteString ( ByteString )
@@ -169,5 +169,5 @@ data SigException
 
 instance Exception SigException where
 #if __GLASGOW_HASKELL__ >= 710
-  showMessage = exMsg
+  displayException = exMsg
 #endif


### PR DESCRIPTION
This patch is needed in order to build properly on GHC 7.10.
